### PR TITLE
Implement the scanner

### DIFF
--- a/bin/lox
+++ b/bin/lox
@@ -1,1 +1,3 @@
 #!/usr/bin/env ruby
+
+Lox::CLI.new($stdin, $stdout).start(ARGV)

--- a/bin/lox
+++ b/bin/lox
@@ -1,3 +1,6 @@
 #!/usr/bin/env ruby
 
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'lox/cli'
+
 Lox::CLI.new($stdin, $stdout).start(ARGV)

--- a/lib/lox/cli.rb
+++ b/lib/lox/cli.rb
@@ -1,3 +1,4 @@
+require 'lox/interpreter'
 require 'lox/logger'
 
 module Lox

--- a/lib/lox/cli.rb
+++ b/lib/lox/cli.rb
@@ -1,3 +1,5 @@
+require 'lox/logger'
+
 module Lox
   class CLI
     def initialize(input, output)

--- a/lib/lox/cli.rb
+++ b/lib/lox/cli.rb
@@ -3,15 +3,29 @@ module Lox
     def initialize(input, output)
       self.input = input
       self.output = output
+      self.logger = Logger.new(output)
+      self.interpreter = Interpreter.new(output, logger)
     end
 
     def start(args)
-      output.puts "Usage: #{$PROGRAM_NAME} [script]"
-      exit(64)
+      case args
+      in [filename]
+        run_file(filename)
+      else
+        output.puts "Usage: #{$PROGRAM_NAME} [script]"
+        exit(64)
+      end
     end
 
     private
 
-    attr_accessor :input, :output
+    attr_accessor :input, :output, :logger, :interpreter
+
+    def run_file(filename)
+      File.open(filename) do |source|
+        interpreter.run(source)
+      end
+      exit(65) if logger.has_errored?
+    end
   end
 end

--- a/lib/lox/cli.rb
+++ b/lib/lox/cli.rb
@@ -11,6 +11,8 @@ module Lox
       case args
       in [filename]
         run_file(filename)
+      in []
+        run_prompt
       else
         output.puts "Usage: #{$PROGRAM_NAME} [script]"
         exit(64)
@@ -26,6 +28,15 @@ module Lox
         interpreter.run(source)
       end
       exit(65) if logger.has_errored?
+    end
+
+    def run_prompt
+      loop do
+        output.print '> '
+        break unless line = input.gets
+        interpreter.run(line)
+        logger.clear_errors
+      end
     end
   end
 end

--- a/lib/lox/cli.rb
+++ b/lib/lox/cli.rb
@@ -1,0 +1,17 @@
+module Lox
+  class CLI
+    def initialize(input, output)
+      self.input = input
+      self.output = output
+    end
+
+    def start(args)
+      output.puts "Usage: #{$PROGRAM_NAME} [script]"
+      exit(64)
+    end
+
+    private
+
+    attr_accessor :input, :output
+  end
+end

--- a/lib/lox/interpreter.rb
+++ b/lib/lox/interpreter.rb
@@ -1,3 +1,5 @@
+require 'lox/scanner'
+
 module Lox
   class Interpreter
     def initialize(output, logger)

--- a/lib/lox/interpreter.rb
+++ b/lib/lox/interpreter.rb
@@ -1,0 +1,20 @@
+module Lox
+  class Interpreter
+    def initialize(output, logger)
+      self.output = output
+      self.logger = logger
+    end
+
+    def run(source)
+      scanner = Scanner.new(source, logger)
+
+      scanner.each_token do |token|
+        output.puts token
+      end
+    end
+
+    private
+
+    attr_accessor :output, :logger
+  end
+end

--- a/lib/lox/logger.rb
+++ b/lib/lox/logger.rb
@@ -1,0 +1,29 @@
+module Lox
+  class Logger
+    def initialize(output)
+      self.output = output
+      clear_errors
+    end
+
+    def error(line, message)
+      report(line, '', message)
+    end
+
+    def clear_errors
+      self.errored = false
+    end
+
+    def has_errored?
+      errored
+    end
+
+    private
+
+    attr_accessor :output, :errored
+
+    def report(line, where, message)
+      output.puts "[line #{line}] Error#{where}: #{message}"
+      self.errored = true
+    end
+  end
+end

--- a/lib/lox/lookahead_iterator.rb
+++ b/lib/lox/lookahead_iterator.rb
@@ -1,0 +1,30 @@
+module Lox
+  class LookaheadIterator
+    def initialize(enumerator)
+      self.enumerator = enumerator
+      self.buffer = []
+    end
+
+    def next
+      if buffer.empty?
+        enumerator.next
+      else
+        buffer.shift
+      end
+    end
+
+    def peek(lookahead: 0)
+      buffer.push(enumerator.next) until lookahead <= buffer.length
+
+      if lookahead < buffer.length
+        buffer.slice(lookahead)
+      else
+        enumerator.peek
+      end
+    end
+
+    private
+
+    attr_accessor :enumerator, :buffer
+  end
+end

--- a/lib/lox/scanner.rb
+++ b/lib/lox/scanner.rb
@@ -1,3 +1,4 @@
+require 'lox/lookahead_iterator'
 require 'lox/token'
 
 module Lox
@@ -27,7 +28,7 @@ module Lox
       }
 
     def initialize(source, logger)
-      self.characters = source.each_char
+      self.characters = LookaheadIterator.new(source.each_char)
       self.logger = logger
       self.line = 1
     end
@@ -69,8 +70,8 @@ module Lox
       end
     end
 
-    def next_character
-      characters.peek
+    def next_character(lookahead: 0)
+      characters.peek(lookahead:)
     end
 
     def read_character(expected = nil)

--- a/lib/lox/scanner.rb
+++ b/lib/lox/scanner.rb
@@ -2,6 +2,20 @@ require 'lox/token'
 
 module Lox
   class Scanner
+    SIMPLE_OPERATORS =
+      {
+        '(' => :left_paren,
+        ')' => :right_paren,
+        '{' => :left_brace,
+        '}' => :right_brace,
+        ',' => :comma,
+        '.' => :dot,
+        '-' => :minus,
+        '+' => :plus,
+        ';' => :semicolon,
+        '*' => :star
+      }
+
     def initialize(source, logger)
       self.characters = source.each_char
       self.logger = logger
@@ -23,9 +37,20 @@ module Lox
     attr_accessor :characters, :logger, :line
 
     def read_token
-      read_character
-      logger.error(line, 'Unexpected character')
-      read_token
+      case next_character
+      when *SIMPLE_OPERATORS.keys
+        lexeme = read_character
+        type = SIMPLE_OPERATORS.fetch(lexeme)
+        Token.new(type:, lexeme:, line:)
+      else
+        read_character
+        logger.error(line, 'Unexpected character')
+        read_token
+      end
+    end
+
+    def next_character
+      characters.peek
     end
 
     def read_character

--- a/lib/lox/scanner.rb
+++ b/lib/lox/scanner.rb
@@ -11,11 +11,25 @@ module Lox
     def each_token
       return enum_for(__method__) unless block_given?
 
+      loop do
+        yield read_token
+      end
+
       yield Token.new(type: :eof, lexeme: '', line:)
     end
 
     private
 
     attr_accessor :characters, :logger, :line
+
+    def read_token
+      read_character
+      logger.error(line, 'Unexpected character')
+      read_token
+    end
+
+    def read_character
+      characters.next
+    end
   end
 end

--- a/lib/lox/scanner.rb
+++ b/lib/lox/scanner.rb
@@ -6,6 +6,12 @@ module Lox
     DOT, EQUAL, QUOTE, SLASH = %w[. = " /]
     WHITESPACE = ' ', "\t", "\r", (NEWLINE = "\n")
 
+    KEYWORDS =
+      %w[
+        and class else false for fun if nil or
+        print return super this true var while
+      ]
+
     SIMPLE_OPERATORS =
       {
         '(' => :left_paren,
@@ -129,8 +135,9 @@ module Lox
       stop_at_eof do
         lexeme << read_character while alpha_numeric?(next_character)
       end
+      type = KEYWORDS.include?(lexeme) ? lexeme.to_sym : :identifier
 
-      Token.new(type: :identifier, lexeme:, line:)
+      Token.new(type:, lexeme:, line:)
     end
 
     def next_character(lookahead: 0)

--- a/lib/lox/scanner.rb
+++ b/lib/lox/scanner.rb
@@ -71,6 +71,8 @@ module Lox
         read_string_token
       when method(:digit?)
         read_number_token
+      when method(:alpha?)
+        read_identifier_token
       else
         read_character
         logger.error(line, 'Unexpected character')
@@ -122,6 +124,15 @@ module Lox
       Token.new(type: :number, lexeme:, literal:, line:)
     end
 
+    def read_identifier_token
+      lexeme = ''
+      stop_at_eof do
+        lexeme << read_character while alpha_numeric?(next_character)
+      end
+
+      Token.new(type: :identifier, lexeme:, line:)
+    end
+
     def next_character(lookahead: 0)
       characters.peek(lookahead:)
     end
@@ -134,6 +145,14 @@ module Lox
 
     def digit?(character)
       ('0'..'9').include?(character)
+    end
+
+    def alpha?(character)
+      ['a'..'z', 'A'..'Z', '_'].any? { _1.include?(character) }
+    end
+
+    def alpha_numeric?(character)
+      alpha?(character) || digit?(character)
     end
 
     def stop_at_eof

--- a/lib/lox/scanner.rb
+++ b/lib/lox/scanner.rb
@@ -1,0 +1,21 @@
+require 'lox/token'
+
+module Lox
+  class Scanner
+    def initialize(source, logger)
+      self.characters = source.each_char
+      self.logger = logger
+      self.line = 1
+    end
+
+    def each_token
+      return enum_for(__method__) unless block_given?
+
+      yield Token.new(type: :eof, lexeme: '', line:)
+    end
+
+    private
+
+    attr_accessor :characters, :logger, :line
+  end
+end

--- a/lib/lox/scanner.rb
+++ b/lib/lox/scanner.rb
@@ -3,7 +3,8 @@ require 'lox/token'
 
 module Lox
   class Scanner
-    EQUAL = '='
+    EQUAL, SLASH = %w[= /]
+    NEWLINE = "\n"
 
     SIMPLE_OPERATORS =
       {
@@ -16,7 +17,8 @@ module Lox
         '-' => :minus,
         '+' => :plus,
         ';' => :semicolon,
-        '*' => :star
+        '*' => :star,
+        SLASH => :slash
       }
 
     COMPOUND_OPERATORS =
@@ -48,6 +50,8 @@ module Lox
     attr_accessor :characters, :logger, :line
 
     def read_token
+      skip_comments
+
       case next_character
       when *SIMPLE_OPERATORS.keys
         lexeme = read_character
@@ -67,6 +71,17 @@ module Lox
         read_character
         logger.error(line, 'Unexpected character')
         read_token
+      end
+    end
+
+    def skip_comments
+      loop do
+        if 2.times.all? { |lookahead| next_character(lookahead:) == SLASH }
+          2.times { read_character(SLASH) }
+          read_character until next_character == NEWLINE
+        else
+          break
+        end
       end
     end
 

--- a/lib/lox/scanner.rb
+++ b/lib/lox/scanner.rb
@@ -53,8 +53,10 @@ module Lox
       characters.peek
     end
 
-    def read_character
-      characters.next
+    def read_character(expected = nil)
+      characters.next.tap do |actual|
+        raise unless actual == expected || expected.nil?
+      end
     end
   end
 end

--- a/lib/lox/scanner.rb
+++ b/lib/lox/scanner.rb
@@ -4,7 +4,7 @@ require 'lox/token'
 module Lox
   class Scanner
     EQUAL, SLASH = %w[= /]
-    NEWLINE = "\n"
+    WHITESPACE = ' ', "\t", "\r", (NEWLINE = "\n")
 
     SIMPLE_OPERATORS =
       {
@@ -50,7 +50,7 @@ module Lox
     attr_accessor :characters, :logger, :line
 
     def read_token
-      skip_comments
+      skip_whitespace_and_comments
 
       case next_character
       when *SIMPLE_OPERATORS.keys
@@ -74,9 +74,12 @@ module Lox
       end
     end
 
-    def skip_comments
+    def skip_whitespace_and_comments
       loop do
-        if 2.times.all? { |lookahead| next_character(lookahead:) == SLASH }
+        if WHITESPACE.include?(next_character)
+          whitespace = read_character
+          self.line += 1 if whitespace == NEWLINE
+        elsif 2.times.all? { |lookahead| next_character(lookahead:) == SLASH }
           2.times { read_character(SLASH) }
           read_character until next_character == NEWLINE
         else

--- a/lib/lox/token.rb
+++ b/lib/lox/token.rb
@@ -1,0 +1,7 @@
+module Lox
+  Token = Struct.new(:type, :lexeme, :literal, :line, keyword_init: true) do
+    def to_s
+      [type.to_s.upcase, lexeme, literal || 'null'].join(' ')
+    end
+  end
+end

--- a/spec/acceptance/lox_interpreter_spec.rb
+++ b/spec/acceptance/lox_interpreter_spec.rb
@@ -2,7 +2,7 @@ require 'open3'
 
 RSpec.describe 'the Lox interpreter' do
   CHAPTERS = {
-    chap04_scanning:    :wip,
+    chap04_scanning:    :done,
     chap06_parsing:     :todo,
     chap07_evaluating:  :todo,
     chap08_statements:  :todo,

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -1,4 +1,16 @@
-RSpec.describe do
+require 'lox/scanner'
+
+RSpec.describe Lox::Scanner do
+  describe '#each_token' do
+    describe 'tokenising' do
+      it 'tokenises the empty string' do
+        expect('').to tokenise_as(
+          { type: :eof }
+        )
+      end
+    end
+  end
+
   matcher :tokenise_as do |*expected_token_attributes|
     match do |source|
       logger = instance_double('Lox::Logger')

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -131,6 +131,10 @@ RSpec.describe Lox::Scanner do
     end
 
     context 'without a trailing newline' do
+      def prepare_source(source)
+        source
+      end
+
       include_examples 'tokenising'
       include_examples 'error handling'
       include_examples 'EOF handling'
@@ -139,7 +143,7 @@ RSpec.describe Lox::Scanner do
 
   matcher :tokenise_as do |*expected_token_attributes|
     match do |source|
-      scanner = Lox::Scanner.new(source, logger)
+      scanner = Lox::Scanner.new(prepare_source(source), logger)
       actual_tokens = scanner.each_token
       actual_token_attributes =
         actual_tokens.zip(expected_token_attributes).map do |actual, expected|

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -128,6 +128,15 @@ RSpec.describe Lox::Scanner do
           { type: :eof }
         )
       end
+
+      it 'tokenises identifiers' do
+        expect('1hello2 _world_').to tokenise_as(
+          { type: :number, literal: 1 },
+          { type: :identifier, lexeme: 'hello2' },
+          { type: :identifier, lexeme: '_world_' },
+          { type: :eof }
+        )
+      end
     end
 
     shared_examples 'error handling' do
@@ -207,6 +216,14 @@ RSpec.describe Lox::Scanner do
         expect('*42.1').to tokenise_as(
           { type: :star },
           { type: :number, literal: 42.1 },
+          { type: :eof }
+        )
+      end
+
+      it 'tokenises a string ending with an identifier' do
+        expect('hello world').to tokenise_as(
+          { type: :identifier, lexeme: 'hello' },
+          { type: :identifier, lexeme: 'world' },
           { type: :eof }
         )
       end

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -78,6 +78,20 @@ RSpec.describe Lox::Scanner do
           { type: :eof }
         )
       end
+
+      it 'tokenises string literals' do
+        expect('"hello world"').to tokenise_as(
+          { type: :string, literal: 'hello world' },
+          { type: :eof }
+        )
+      end
+
+      it 'records a string literal’s final line number' do
+        expect(%Q{";)\n;)\n;)"}).to tokenise_as(
+          { type: :string, literal: ";)\n;)\n;)", line: 3 },
+          { type: :eof }
+        )
+      end
     end
 
     shared_examples 'error handling' do
@@ -87,6 +101,13 @@ RSpec.describe Lox::Scanner do
           { type: :right_paren },
           { type: :eof }
         ).with_error('Unexpected character')
+      end
+
+      it 'reports an error for an unterminated string literal' do
+        expect('* "hello').to tokenise_as(
+          { type: :star },
+          { type: :eof }
+        ).with_error('Unterminated string')
       end
     end
 

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe Lox::Scanner do
           { type: :eof }
         )
       end
+
+      it 'tokenises slashes' do
+        expect('(/)').to tokenise_as(
+          { type: :left_paren },
+          { type: :slash },
+          { type: :right_paren },
+          { type: :eof }
+        )
+      end
+
+      it 'ignores comments' do
+        expect('(/)// hello world').to tokenise_as(
+          { type: :left_paren },
+          { type: :slash },
+          { type: :right_paren },
+          { type: :eof }
+        )
+      end
     end
 
     describe 'error handling' do
@@ -63,6 +81,28 @@ RSpec.describe Lox::Scanner do
         expect('*<=').to tokenise_as(
           { type: :star },
           { type: :less_equal },
+          { type: :eof }
+        )
+      end
+
+      it 'tokenises a string ending with a slash' do
+        expect('*/').to tokenise_as(
+          { type: :star },
+          { type: :slash },
+          { type: :eof }
+        )
+      end
+
+      it 'tokenises a string ending with an empty comment' do
+        expect('*//').to tokenise_as(
+          { type: :star },
+          { type: :eof }
+        )
+      end
+
+      it 'tokenises a string ending with a non-empty comment' do
+        expect('*// world').to tokenise_as(
+          { type: :star },
           { type: :eof }
         )
       end

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -56,6 +56,28 @@ RSpec.describe Lox::Scanner do
           { type: :eof }
         )
       end
+
+      it 'ignores whitespace' do
+        expect(" ( \t ) \n { \r } ").to tokenise_as(
+          { type: :left_paren },
+          { type: :right_paren },
+          { type: :left_brace },
+          { type: :right_brace },
+          { type: :eof }
+        )
+      end
+
+      it 'keeps track of the current line number' do
+        expect(";)\n;)\n;)").to tokenise_as(
+          { type: :semicolon, line: 1 },
+          { type: :right_paren, line: 1 },
+          { type: :semicolon, line: 2 },
+          { type: :right_paren, line: 2 },
+          { type: :semicolon, line: 3 },
+          { type: :right_paren, line: 3 },
+          { type: :eof }
+        )
+      end
     end
 
     describe 'error handling' do

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe Lox::Scanner do
           { type: :eof }
         )
       end
+
+      it 'tokenises compound operators' do
+        expect('==!!=<<=>>==').to tokenise_as(
+          { type: :equal_equal },
+          { type: :bang },
+          { type: :bang_equal },
+          { type: :less },
+          { type: :less_equal },
+          { type: :greater },
+          { type: :greater_equal },
+          { type: :equal },
+          { type: :eof }
+        )
+      end
     end
 
     describe 'error handling' do
@@ -33,6 +47,24 @@ RSpec.describe Lox::Scanner do
           { type: :right_paren },
           { type: :eof }
         ).with_error('Unexpected character')
+      end
+    end
+
+    describe 'EOF handling' do
+      it 'tokenises a string ending with a one-character compound operator' do
+        expect('*<').to tokenise_as(
+          { type: :star },
+          { type: :less },
+          { type: :eof }
+        )
+      end
+
+      it 'tokenises a string ending with a two-character compound operator' do
+        expect('*<=').to tokenise_as(
+          { type: :star },
+          { type: :less_equal },
+          { type: :eof }
+        )
       end
     end
   end

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -137,6 +137,31 @@ RSpec.describe Lox::Scanner do
           { type: :eof }
         )
       end
+
+      it 'tokenises keywords' do
+        expect(
+          'and class else false for fun if nil or ' \
+          'print return super this true var while'
+        ).to tokenise_as(
+          { type: :and },
+          { type: :class },
+          { type: :else },
+          { type: :false },
+          { type: :for },
+          { type: :fun },
+          { type: :if },
+          { type: :nil },
+          { type: :or },
+          { type: :print },
+          { type: :return },
+          { type: :super },
+          { type: :this },
+          { type: :true },
+          { type: :var },
+          { type: :while },
+          { type: :eof }
+        )
+      end
     end
 
     shared_examples 'error handling' do

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe do
+  matcher :tokenise_as do |*expected_token_attributes|
+    match do |source|
+      logger = instance_double('Lox::Logger')
+      scanner = Lox::Scanner.new(source, logger)
+      actual_tokens = scanner.each_token
+      actual_token_attributes =
+        actual_tokens.zip(expected_token_attributes).map do |actual, expected|
+          expected ? actual.to_h.slice(*expected.keys) : actual.to_h
+        end
+      @actual = actual_token_attributes
+
+      expect(actual_token_attributes).to eq expected_token_attributes
+    end
+
+    diffable
+  end
+end

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -2,7 +2,7 @@ require 'lox/scanner'
 
 RSpec.describe Lox::Scanner do
   describe '#each_token' do
-    describe 'tokenising' do
+    shared_examples 'tokenising' do
       it 'tokenises the empty string' do
         expect('').to tokenise_as(
           { type: :eof }
@@ -80,7 +80,7 @@ RSpec.describe Lox::Scanner do
       end
     end
 
-    describe 'error handling' do
+    shared_examples 'error handling' do
       it 'skips an unexpected character and reports an error' do
         expect('(#)').to tokenise_as(
           { type: :left_paren },
@@ -90,7 +90,7 @@ RSpec.describe Lox::Scanner do
       end
     end
 
-    describe 'EOF handling' do
+    shared_examples 'EOF handling' do
       it 'tokenises a string ending with a one-character compound operator' do
         expect('*<').to tokenise_as(
           { type: :star },
@@ -129,6 +129,10 @@ RSpec.describe Lox::Scanner do
         )
       end
     end
+
+    include_examples 'tokenising'
+    include_examples 'error handling'
+    include_examples 'EOF handling'
   end
 
   matcher :tokenise_as do |*expected_token_attributes|

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -8,11 +8,29 @@ RSpec.describe Lox::Scanner do
           { type: :eof }
         )
       end
+
+      it 'tokenises simple operators' do
+        expect('(){},.-+;*').to tokenise_as(
+          { type: :left_paren },
+          { type: :right_paren },
+          { type: :left_brace },
+          { type: :right_brace },
+          { type: :comma },
+          { type: :dot },
+          { type: :minus },
+          { type: :plus },
+          { type: :semicolon },
+          { type: :star },
+          { type: :eof }
+        )
+      end
     end
 
     describe 'error handling' do
       it 'skips an unexpected character and reports an error' do
-        expect('#').to tokenise_as(
+        expect('(#)').to tokenise_as(
+          { type: :left_paren },
+          { type: :right_paren },
           { type: :eof }
         ).with_error('Unexpected character')
       end

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -139,6 +139,16 @@ RSpec.describe Lox::Scanner do
       include_examples 'error handling'
       include_examples 'EOF handling'
     end
+
+    context 'with a trailing newline' do
+      def prepare_source(source)
+        "#{source}\n"
+      end
+
+      include_examples 'tokenising'
+      include_examples 'error handling'
+      include_examples 'EOF handling'
+    end
   end
 
   matcher :tokenise_as do |*expected_token_attributes|

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Lox::Scanner do
         )
       end
     end
+
+    describe 'error handling' do
+      it 'skips an unexpected character and reports an error' do
+        expect('#').to tokenise_as(
+          { type: :eof }
+        ).with_error('Unexpected character')
+      end
+    end
   end
 
   matcher :tokenise_as do |*expected_token_attributes|

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Lox::Scanner do
 
   matcher :tokenise_as do |*expected_token_attributes|
     match do |source|
-      logger = instance_double('Lox::Logger')
       scanner = Lox::Scanner.new(source, logger)
       actual_tokens = scanner.each_token
       actual_token_attributes =
@@ -23,6 +22,14 @@ RSpec.describe Lox::Scanner do
       @actual = actual_token_attributes
 
       expect(actual_token_attributes).to eq expected_token_attributes
+    end
+
+    chain :with_error do |message|
+      expect(logger).to receive(:error).with(a_kind_of(Integer), message)
+    end
+
+    def logger
+      @logger ||= instance_double('Lox::Logger')
     end
 
     diffable

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -130,9 +130,11 @@ RSpec.describe Lox::Scanner do
       end
     end
 
-    include_examples 'tokenising'
-    include_examples 'error handling'
-    include_examples 'EOF handling'
+    context 'without a trailing newline' do
+      include_examples 'tokenising'
+      include_examples 'error handling'
+      include_examples 'EOF handling'
+    end
   end
 
   matcher :tokenise_as do |*expected_token_attributes|

--- a/spec/integration/scanner_spec.rb
+++ b/spec/integration/scanner_spec.rb
@@ -92,6 +92,42 @@ RSpec.describe Lox::Scanner do
           { type: :eof }
         )
       end
+
+      it 'tokenises numbers without a fractional part' do
+        expect('123 456').to tokenise_as(
+          { type: :number, literal: 123 },
+          { type: :number, literal: 456 },
+          { type: :eof }
+        )
+      end
+
+      it 'tokenises numbers with a fractional part' do
+        expect('123.456 78.9').to tokenise_as(
+          { type: :number, literal: 123.456 },
+          { type: :number, literal: 78.9 },
+          { type: :eof }
+        )
+      end
+
+      it 'tokenises a number before a dot' do
+        expect('123. 78.').to tokenise_as(
+          { type: :number, literal: 123 },
+          { type: :dot },
+          { type: :number, literal: 78 },
+          { type: :dot },
+          { type: :eof }
+        )
+      end
+
+      it 'tokenises a number after a dot' do
+        expect('.123 .78').to tokenise_as(
+          { type: :dot },
+          { type: :number, literal: 123 },
+          { type: :dot },
+          { type: :number, literal: 78 },
+          { type: :eof }
+        )
+      end
     end
 
     shared_examples 'error handling' do
@@ -146,6 +182,31 @@ RSpec.describe Lox::Scanner do
       it 'tokenises a string ending with a non-empty comment' do
         expect('*// world').to tokenise_as(
           { type: :star },
+          { type: :eof }
+        )
+      end
+
+      it 'tokenises a string ending with a number with no fractional part' do
+        expect('*42').to tokenise_as(
+          { type: :star },
+          { type: :number, literal: 42.0 },
+          { type: :eof }
+        )
+      end
+
+      it 'tokenises a string ending with a number followed by a dot' do
+        expect('*42.').to tokenise_as(
+          { type: :star },
+          { type: :number, literal: 42.0 },
+          { type: :dot },
+          { type: :eof }
+        )
+      end
+
+      it 'tokenises a string ending with a number with a fractional part' do
+        expect('*42.1').to tokenise_as(
+          { type: :star },
+          { type: :number, literal: 42.1 },
           { type: :eof }
         )
       end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -1,0 +1,31 @@
+require 'stringio'
+require 'lox/cli'
+
+RSpec.describe Lox::CLI do
+  let(:input) { double }
+  let(:output) { double }
+
+  subject(:cli) { Lox::CLI.new(input, output) }
+
+  describe '#start' do
+    context 'with unrecognised arguments' do
+      let(:output) { StringIO.new }
+      let(:arguments) { [double, double] }
+
+      it 'prints a usage message' do
+        begin
+          cli.start(arguments)
+        rescue SystemExit
+        end
+
+        expect(output.string).to start_with('Usage:')
+      end
+
+      it 'exits with status 64 (`EX_USAGE`)' do
+        expect { cli.start(arguments) }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq 64
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -55,6 +55,37 @@ RSpec.describe Lox::CLI do
       end
     end
 
+    context 'with no arguments' do
+      let(:lines) { ["hello world\n", "goodbye world\n"] }
+      let(:input) { StringIO.new(lines.join) }
+      let(:output) { StringIO.new }
+      let(:arguments) { [] }
+
+      before do
+        allow(interpreter).to receive(:run)
+        allow(logger).to receive(:clear_errors)
+        allow(logger).to receive(:has_errored?).and_return(false)
+      end
+
+      it 'prompts for user input' do
+        cli.start(arguments)
+        expect(output.string).to start_with('> ')
+      end
+
+      it 'reads and evaluates the user input' do
+        cli.start(arguments)
+
+        lines.each do |line|
+          expect(interpreter).to have_received(:run).with(line).ordered
+        end
+      end
+
+      it 'clears the logger’s error state after each evaluation' do
+        cli.start(arguments)
+        expect(logger).to have_received(:clear_errors).exactly(lines.length).times
+      end
+    end
+
     context 'with unrecognised arguments' do
       let(:output) { StringIO.new }
       let(:arguments) { [double, double] }

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -4,10 +4,57 @@ require 'lox/cli'
 RSpec.describe Lox::CLI do
   let(:input) { double }
   let(:output) { double }
+  let(:logger) { instance_double('Lox::Logger') }
+  let(:interpreter) { instance_double('Lox::Interpreter') }
 
   subject(:cli) { Lox::CLI.new(input, output) }
 
+  before do
+    class_double('Lox::Logger', new: logger).as_stubbed_const
+    class_double('Lox::Interpreter', new: interpreter).as_stubbed_const
+  end
+
   describe '#start' do
+    context 'with a filename argument' do
+      let(:file) { double }
+      let(:filename) { double }
+      let(:arguments) { [filename] }
+
+      before do
+        allow(File).to receive(:open).and_yield(file)
+        allow(interpreter).to receive(:run)
+        allow(logger).to receive(:has_errored?).and_return(false)
+      end
+
+      it 'opens the file' do
+        cli.start(arguments)
+        expect(File).to have_received(:open).with(filename)
+      end
+
+      it 'evaluates the file' do
+        cli.start(arguments)
+        expect(interpreter).to have_received(:run).with(file)
+      end
+
+      context 'when there are no errors' do
+        it 'returns normally' do
+          expect { cli.start(arguments) }.not_to raise_error
+        end
+      end
+
+      context 'when there are errors' do
+        before do
+          allow(logger).to receive(:has_errored?).and_return(true)
+        end
+
+        it 'exits with status 65 (`EX_DATAERR`)' do
+          expect { cli.start(arguments) }.to raise_error(SystemExit) do |error|
+            expect(error.status).to eq 65
+          end
+        end
+      end
+    end
+
     context 'with unrecognised arguments' do
       let(:output) { StringIO.new }
       let(:arguments) { [double, double] }

--- a/spec/unit/interpreter_spec.rb
+++ b/spec/unit/interpreter_spec.rb
@@ -1,0 +1,41 @@
+require 'stringio'
+require 'lox/interpreter'
+
+RSpec.describe Lox::Interpreter do
+  let(:output) { double }
+  let(:logger) { instance_double('Lox::Logger') }
+  let(:scanner) { instance_double('Lox::Scanner') }
+
+  subject(:interpreter) { Lox::Interpreter.new(output, logger) }
+
+  before do
+    class_double('Lox::Scanner', new: scanner).as_stubbed_const
+  end
+
+  describe '#run' do
+    let(:output) { StringIO.new }
+    let(:source) { double }
+    let(:token_one) { instance_double('Lox::Token', to_s: 'token one') }
+    let(:token_two) { instance_double('Lox::Token', to_s: 'token two') }
+    let(:tokens) { [token_one, token_two] }
+
+    before do
+      allow(scanner).to receive(:each_token).and_yield(token_one).and_yield(token_two)
+    end
+
+    it 'fetches the tokens from the scanner' do
+      interpreter.run(source)
+      expect(scanner).to have_received(:each_token)
+    end
+
+    it 'converts each token to a string' do
+      interpreter.run(source)
+      expect(tokens).to all have_received(:to_s)
+    end
+
+    it 'outputs the string representation of each token' do
+      interpreter.run(source)
+      expect(output.string).to eq "token one\ntoken two\n"
+    end
+  end
+end

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -1,0 +1,40 @@
+require 'stringio'
+require 'lox/logger'
+
+RSpec.describe Lox::Logger do
+  let(:output) { double }
+
+  subject(:logger) { Lox::Logger.new(output) }
+
+  context 'when no errors have been logged' do
+    it { is_expected.not_to have_errored }
+  end
+
+  context 'when an error has been logged' do
+    let(:output) { StringIO.new }
+    let(:line) { 42 }
+    let(:message) { 'Something went wrong' }
+
+    before do
+      logger.error(line, message)
+    end
+
+    it { is_expected.to have_errored }
+
+    it 'includes the line number in the log message' do
+      expect(output.string).to include "line #{line}"
+    end
+
+    it 'includes the error in the log message' do
+      expect(output.string).to include message
+    end
+
+    context 'and then cleared' do
+      before do
+        logger.clear_errors
+      end
+
+      it { is_expected.not_to have_errored }
+    end
+  end
+end

--- a/spec/unit/lookahead_iterator_spec.rb
+++ b/spec/unit/lookahead_iterator_spec.rb
@@ -1,0 +1,133 @@
+require 'lox/lookahead_iterator'
+
+RSpec.describe Lox::LookaheadIterator do
+  let(:enumerator) { 'hello world'.each_char }
+
+  subject(:lookahead_iterator) { Lox::LookaheadIterator.new(enumerator) }
+
+  shared_examples 'iterating from the beginning' do
+    describe '#each' do
+      it 'iterates through the early elements' do
+        expect(5.times.map { lookahead_iterator.next }).to eq %w[h e l l o]
+      end
+
+      it 'raises StopIteration if it iterates too far' do
+        expect { 12.times { lookahead_iterator.next } }.to raise_error(StopIteration)
+      end
+    end
+
+    describe '#peek' do
+      it 'looks ahead by a single element by default' do
+        expect(lookahead_iterator.peek).to eq 'h'
+      end
+
+      it 'looks ahead by several elements' do
+        expect(lookahead_iterator.peek(lookahead: 4)).to eq 'o'
+      end
+
+      it 'raises StopIteration if it looks ahead too far' do
+        expect { lookahead_iterator.peek(lookahead: 11) }.to raise_error(StopIteration)
+      end
+    end
+  end
+
+  shared_examples 'iterating from halfway through' do
+    describe '#each' do
+      it 'iterates through the late elements' do
+        expect(5.times.map { lookahead_iterator.next }).to eq %w[w o r l d]
+      end
+
+      it 'raises StopIteration if it iterates too far' do
+        expect { 6.times { lookahead_iterator.next } }.to raise_error(StopIteration)
+      end
+    end
+
+    describe '#peek' do
+      it 'looks ahead by a single element by default' do
+        expect(lookahead_iterator.peek).to eq 'w'
+      end
+
+      it 'looks ahead by several elements' do
+        expect(lookahead_iterator.peek(lookahead: 4)).to eq 'd'
+      end
+
+      it 'raises StopIteration if it looks ahead too far' do
+        expect { lookahead_iterator.peek(lookahead: 5) }.to raise_error(StopIteration)
+      end
+    end
+  end
+
+  context 'before any iteration or lookahead' do
+    include_examples 'iterating from the beginning'
+  end
+
+  context 'after some lookahead' do
+    before do
+      6.times { |lookahead| lookahead_iterator.peek(lookahead:) }
+    end
+
+    include_examples 'iterating from the beginning'
+  end
+
+  context 'after some iteration' do
+    before do
+      6.times { lookahead_iterator.next }
+    end
+
+    include_examples 'iterating from halfway through'
+  end
+
+  context 'after some iteration and lookahead' do
+    before do
+      6.times { lookahead_iterator.next }
+      5.times { |lookahead| lookahead_iterator.peek(lookahead:) }
+    end
+
+    include_examples 'iterating from halfway through'
+  end
+
+  describe 'peeking whenever possible' do
+    let(:enumerator) { double }
+
+    before do
+      allow(enumerator).to receive(:peek)
+      allow(enumerator).to receive(:next)
+    end
+
+    context 'before any lookahead' do
+      it 'peeks the underlying enumerator if possible' do
+        expect(enumerator).not_to receive(:next)
+        expect(enumerator).to receive(:peek).once
+
+        lookahead_iterator.peek
+      end
+
+      it 'iterates and peeks the underlying enumerator if necessary' do
+        expect(enumerator).to receive(:next).twice.ordered
+        expect(enumerator).to receive(:peek).once.ordered
+
+        lookahead_iterator.peek(lookahead: 2)
+      end
+    end
+
+    context 'after some lookahead' do
+      before do
+        lookahead_iterator.peek(lookahead: 2)
+      end
+
+      it 'peeks the underlying enumerator if possible' do
+        expect(enumerator).not_to receive(:next)
+        expect(enumerator).to receive(:peek).once
+
+        lookahead_iterator.peek(lookahead: 2)
+      end
+
+      it 'iterates and peeks the underlying enumerator if necessary' do
+        expect(enumerator).to receive(:next).once.ordered
+        expect(enumerator).to receive(:peek).once.ordered
+
+        lookahead_iterator.peek(lookahead: 3)
+      end
+    end
+  end
+end

--- a/spec/unit/token_spec.rb
+++ b/spec/unit/token_spec.rb
@@ -1,0 +1,49 @@
+require 'lox/token'
+
+RSpec.describe Lox::Token do
+  let(:type) { double }
+  let(:lexeme) { double }
+  let(:line) { double }
+
+  context 'without a literal' do
+    subject(:token) { Lox::Token.new(type:, lexeme:, line:) }
+
+    describe 'getters' do
+      it { is_expected.to have_attributes(type:, lexeme:, line:) }
+      it { is_expected.to have_attributes(literal: nil) }
+    end
+
+    describe '#to_s' do
+      before do
+        allow(type).to receive(:to_s).and_return('star')
+        allow(lexeme).to receive(:to_s).and_return('*')
+      end
+
+      it 'concatenates the type, lexeme and “null”, upcasing the type' do
+        expect(token.to_s).to eq 'STAR * null'
+      end
+    end
+  end
+
+  context 'with a literal' do
+    let(:literal) { double }
+
+    subject(:token) { Lox::Token.new(type:, lexeme:, literal:, line:) }
+
+    describe 'getters' do
+      it { is_expected.to have_attributes(type:, lexeme:, literal:, line:) }
+    end
+
+    describe '#to_s' do
+      before do
+        allow(type).to receive(:to_s).and_return('number')
+        allow(lexeme).to receive(:to_s).and_return('42')
+        allow(literal).to receive(:to_s).and_return('42.0')
+      end
+
+      it 'concatenates the type, lexeme and literal, upcasing the type' do
+        expect(token.to_s).to eq 'NUMBER 42 42.0'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the Lox scanner from [chapter 4](https://craftinginterpreters.com/scanning.html) of _Crafting Interpreters_.

Its design is slightly different from the one in the book: `Lox::Scanner` consumes an `Enumerator` of characters and incrementally produces an `Enumerator` of tokens, and the token-generating methods (e.g. `#read_string_token`) are responsible for reading an entire lexeme from start to finish, not just its trailing characters. There’s also some separation of concerns within the interpreter framework (e.g. `Lox::CLI`, `Lox::Logger`, `Lox::Interpreter`) rather than everything being combined into a single `Lox` class.

The commits follow an outside-in, [double loop TDD](http://coding-is-like-cooking.info/2013/04/outside-in-development-with-double-loop-tdd/) style: the book’s official [acceptance tests](https://github.com/munificent/craftinginterpreters#testing) are used to decide which piece to build next, and unit tests are used to implement each piece in isolation before its collaborators exist, which in turn test-drives the design of their API. The exception to this is `Lox::Scanner`, which is implemented in [book order](https://craftinginterpreters.com/scanning.html#the-scanner-class) to make it easier to follow, and tested in integration with its collaborators `Lox::Token` and `Lox::LookaheadIterator` to reliably verify its inherently stateful behaviour.

Here’s a video with some more information:

<div align="center">
<a href="https://youtu.be/5JtqqrJ5PK0"><img src="https://img.youtube.com/vi/5JtqqrJ5PK0/0.jpg"></a>
</div>
